### PR TITLE
Suggestion for improved german translation

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -13,7 +13,7 @@
   <string name="settings">Einstellungen</string>
   <string name="theme">Ausrichtung</string>
   <string name="sendFeedback">Feedback einsenden</string>
-  <string name="showBatterySummary">Zeige Akkustatus</string>
+  <string name="showBatterySummary">Zeige Batteriestatus</string>
   <string name="propHeader_BatteryInfo">Batteriestand</string>
   <string name="propHeader_Properties">Widget-Einstellungen</string>
   <string name="propHeader_Feedback">Feedback</string>
@@ -51,8 +51,8 @@
   <string name="sett_textPos_Bottom">Unten</string>
   <string name="sett_textPos_Below">Unter den Icons</string>
   <string name="sett_battSel_Both">Beide</string>
-  <string name="sett_battSel_Main">Nur den internen Akku</string>
-  <string name="sett_battSel_Dock">Nur den Dock-Akku</string>
+  <string name="sett_battSel_Main">Nur interne Batterie</string>
+  <string name="sett_battSel_Dock">Nur Dock-Batterie</string>
   <string name="sett_textColor_White">Weiß</string>
   <string name="sett_textColor_Black">Schwarz</string>
   <string name="sett_margin_None">Kein</string>
@@ -64,7 +64,7 @@
   <string name="sett_defaultDaysTab_3">3 Tage</string>
   <string name="sett_defaultDaysTab_7">7 Tage</string>
   <string name="sett_defaultDaysTab_30">30 Tage</string>
-  <string name="about_0_head">Das Dual Battery Widget wurde ursprünglich für das Asus Eee Pad Transformer entwickelt, ein Gerät mit zweitem Akku in der Docking-Station. Leider bieten die standard Android-Tools keine Möglichkeit, die Kapazität des zweiten Akkus anzuzeigen. Diese App wurde daher erstellt, um diese Lücke zu füllen.
+  <string name="about_0_head">Das Dual Battery Widget wurde ursprünglich für das Asus Eee Pad Transformer entwickelt, ein Gerät mit zweiter Batterie in der Docking-Station. Leider bieten die standard Android-Tools keine Möglichkeit, die Kapazität der zweiten Batterie anzuzeigen. Diese App wurde daher erstellt, um diese Lücke zu füllen.
 \n</string>
   <string name="about_1_author">Erstellt von: Artiom Chilaru</string>
   <string name="about_2_projectpage">Projektseite:</string>
@@ -112,7 +112,7 @@ Sag uns was du über das Widget denkst oder was du in den kommenden Versionen se
   <string name="donation_play_7">Wenn du wirklich Nummer 7 magst (£7,77)</string>
   <string name="donate_paypal">PayPal</string>
   <string name="donation_paypal">Zu PayPal gehen</string>
-  <string name="alert_just_swapped">WICHTIG! Mit dieser Version haben wir die Standardreihenfolge der Widget-Icons geändert (du kannst sie wieder in den Widget-Einstellungen wechseln). Um die neuen Asus-Updates wieder zu spiegeln, werden der Dock-Akku links und die Hauptbatterie auf der rechten Seite erscheinen!</string>
+  <string name="alert_just_swapped">WICHTIG! Mit dieser Version haben wir die Standardreihenfolge der Widget-Icons geändert (du kannst sie wieder in den Widget-Einstellungen wechseln). Um die neuen Asus-Updates wieder zu spiegeln, werden die Dock-Batterie links und die Hauptbatterie auf der rechten Seite erscheinen!</string>
 
   <string name="theme_default">Standard</string>
   <string name="theme_default_sideways">Gekippt</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -11,50 +11,51 @@
   <string name="battery_main">Intern</string>
   <string name="battery_dock">Dock</string>
   <string name="settings">Einstellungen</string>
+  <string name="theme">Ausrichtung</string>
   <string name="sendFeedback">Feedback einsenden</string>
   <string name="showBatterySummary">Zeige Akkustatus</string>
-  <string name="propHeader_BatteryInfo">Akkustand</string>
+  <string name="propHeader_BatteryInfo">Batteriestand</string>
   <string name="propHeader_Properties">Widget-Einstellungen</string>
   <string name="propHeader_Feedback">Feedback</string>
   <string name="propHeader_Donate">Spenden</string>
   <string name="propHeader_About">Über</string>
   <string name="propTitle_General">Allgemein</string>
-  <string name="propTitle_Dock">Einstellungen für den Akku im Dock</string>
-  <string name="prop_batterySelection">Akku auswählen</string>
-  <string name="prop_alwaysShowDock">Immer den Dock-Akku anzeigen</string>
+  <string name="propTitle_Dock">Einstellungen für die Batterie im Dock</string>
+  <string name="prop_batterySelection">Batterie auswählen</string>
+  <string name="prop_alwaysShowDock">Immer die Dock-Batterie anzeigen</string>
   <string name="prop_alwaysShowDock_summary">Zeige die Dock-Batterie auch, wenn die externe Tastatur nicht verbunden ist</string>
-  <string name="prop_showNotDockedMsg">Status im ungedockten Zustand anzeigen lassen</string>
-  <string name="prop_showNotDockedMsg_summary">Wenn das Dock nicht angeschlossen ist, soll eine Nachricht über den fehlenden externen Akku angezeigt werden.</string>
+  <string name="prop_showNotDockedMsg">Status im ungedockten Zustand weiterhin anzeigen</string>
+  <string name="prop_showNotDockedMsg_summary">Wenn das Dock nicht angeschlossen ist, soll eine Nachricht über die fehlenden externe Batterie angezeigt werden.</string>
   <string name="prop_textPosition">Textposition</string>
-  <string name="prop_textPosition_summary">Platz für die Anzeige des Akkustatus (%s)</string>
+  <string name="prop_textPosition_summary">Position der Anzeige des Batteriestatus (%s)</string>
   <string name="prop_textSize">Textgröße</string>
   <string name="prop_textColor">Textfarbe</string>
-  <string name="prop_margin">Seitenwahl für die Anzeige</string>
-  <string name="prop_margin_summary">Der Abstand soll so groß wie der Text sein (%s)</string>
-  <string name="prop_showLabel">Das Akku-Label anzeigen lassen</string>
+  <string name="prop_margin">Umrandung für die Anzeige</string>
+  <string name="prop_margin_summary">Der Rand ist so groß wie der Text (%s)</string>
+  <string name="prop_showLabel">Batterie-Bezeichnung anzeigen</string>
   <string name="prop_showLabel_summary">
-        Zeigt das Akku-Label am unteren Rand.
-        \nKann überschrieben werden, wenn der Akkustatus am gleichen Ort angezeigt wird.
+        Zeigt die Batterie-Bezeichnung am unteren Rand.
+        \nWird überschrieben, wenn der Batteriestatus am gleichen Ort angezeigt wird.
     </string>
-  <string name="prop_showDockHistory">Zeige altes Label</string>
-  <string name="prop_showDockHistory_summary">Zeige den zuletzt gespeicherten Stand des Dock-Akkus, wenn das Dock nicht angeschlossen ist.</string>
-  <string name="prop_swapBatteries">Wechsle die Batterie-Icons</string>
+  <string name="prop_showDockHistory">Zeige letzten Ladestand</string>
+  <string name="prop_showDockHistory_summary">Zeigt den zuletzt gespeicherten Stand der Dock-Batterie, wenn das Dock nicht angeschlossen ist.</string>
+  <string name="prop_swapBatteries">Reihenfolge der Batterie-Icons tauschen</string>
   <string name="prop_tempUnits">Einheit für die Temperatur</string>
   <string name="prop_showNotificationIcon">Zeige Benachrichtigungs-Icon</string>
-  <string name="prop_showNotificationIcon_summary">Zeige die Akkukapazität in der Benachrichtigungsleiste</string>
-  <string name="prop_defaultDaysTab">Standardzeitraum für Geschichte</string>
-  <string name="sett_textPos_Invisible">Unsichtbar</string>
-  <string name="sett_textPos_Above">Darüber</string>
+  <string name="prop_showNotificationIcon_summary">Zeigt die Batteriekapazität in der Benachrichtigungsleiste</string>
+  <string name="prop_defaultDaysTab">Standardzeitraum für Historie</string>
+  <string name="sett_textPos_Invisible">Ausblenden</string>
+  <string name="sett_textPos_Above">Über den Icons</string>
   <string name="sett_textPos_Top">Oben</string>
-  <string name="sett_textPos_Middle">Zentrum</string>
+  <string name="sett_textPos_Middle">Im Zentrum</string>
   <string name="sett_textPos_Bottom">Unten</string>
-  <string name="sett_textPos_Below">Darunter</string>
+  <string name="sett_textPos_Below">Unter den Icons</string></string>
   <string name="sett_battSel_Both">Beide</string>
   <string name="sett_battSel_Main">Nur den internen Akku</string>
   <string name="sett_battSel_Dock">Nur den Dock-Akku</string>
   <string name="sett_textColor_White">Weiß</string>
   <string name="sett_textColor_Black">Schwarz</string>
-  <string name="sett_margin_None">Keine</string>
+  <string name="sett_margin_None">Kein</string>
   <string name="sett_margin_Top">Oben</string>
   <string name="sett_margin_Bottom">Unten</string>
   <string name="sett_margin_Both">Beide</string>
@@ -76,30 +77,30 @@
 
 Sag uns was du über das Widget denkst oder was du in den kommenden Versionen sehen möchtest und ich werde auf dich zurück kommen.     </string>
   <string name="feedback_hint">Bitte gib dein Feedback ein</string>
-  <string name="battery_info_status_label">Akkustatus:</string>
-  <string name="battery_info_last_charged_label">Letzter Zeitpunkt der Aufladung:</string>
-  <string name="battery_info_scale_label">Akkukapazität:</string>
-  <string name="battery_info_level_label">Akkustand:</string>
-  <string name="battery_info_health_label">Gesundheitszustand des Akkus:</string>
-  <string name="battery_info_technology_label">Akku-Art:</string>
-  <string name="battery_info_voltage_label">Akkuspannung:</string>
+  <string name="battery_info_status_label">Status der internen Batterie:</string>
+  <string name="battery_info_last_charged_label">Letzter Lade-Zeitpunkt:</string>
+  <string name="battery_info_scale_label">Batteriekapazität:</string>
+  <string name="battery_info_level_label">Batterie Ladestand:</string>
+  <string name="battery_info_health_label">Gesundheitszustand der Batterie:</string>
+  <string name="battery_info_technology_label">Batterie-Art:</string>
+  <string name="battery_info_voltage_label">Batteriespannung:</string>
   <string name="battery_info_voltage_units_mV">mV</string>
   <string name="battery_info_voltage_units_V">V</string>
-  <string name="battery_info_temperature_label">Akkutemperatur:</string>
-  <string name="battery_info_dock_status_label">Dock-Akku Status:</string>
-  <string name="battery_info_dock_level_label">Dock Ladekapazität:</string>
+  <string name="battery_info_temperature_label">Batterietemperatur:</string>
+  <string name="battery_info_dock_status_label">Status der Dock-Batterie:</string>
+  <string name="battery_info_dock_level_label">Dock Ladestand:</string>
   <string name="battery_info_dock_last_connected_label">Das Dock war zuletzt angeschlossen:</string>
-  <string name="battery_info_status_charging">Lade</string>
-  <string name="battery_info_status_discharging">Entlade</string>
-  <string name="battery_info_status_not_charging">Lade nicht auf</string>
+  <string name="battery_info_status_charging">Lädt</string>
+  <string name="battery_info_status_discharging">Entlädt</string>
+  <string name="battery_info_status_not_charging">Lädt nicht</string>
   <string name="battery_info_status_full">Voll</string>
   <string name="battery_info_health_good">Gut</string>
   <string name="battery_info_health_overheat">Überhitzt</string>
   <string name="battery_info_health_dead">Tot</string>
   <string name="battery_info_health_over_voltage">Überspannung</string>
   <string name="battery_info_health_unspecified_failure">Unbekannter Fehler</string>
-  <string name="battery_info_dock_status_charging">Lade</string>
-  <string name="battery_info_dock_status_discharging">Entlade</string>
+  <string name="battery_info_dock_status_charging">Lädt</string>
+  <string name="battery_info_dock_status_discharging">Entlädt</string>
   <string name="battery_info_dock_status_docked">Angedockt</string>
   <string name="battery_info_dock_status_undocked">Nicht angedockt</string>
   <string name="donate_head">Danke, dass du dich für die Unterstützung meines Widgets entschieden hast. Deine Hilfe wird sehr geschätzt!
@@ -112,4 +113,7 @@ Sag uns was du über das Widget denkst oder was du in den kommenden Versionen se
   <string name="donate_paypal">PayPal</string>
   <string name="donation_paypal">Zu PayPal gehen</string>
   <string name="alert_just_swapped">WICHTIG! Mit dieser Version haben wir die Standardreihenfolge der Widget-Icons geändert (du kannst sie wieder in den Widget-Einstellungen wechseln). Um die neuen Asus-Updates wieder zu spiegeln, werden der Dock-Akku links und die Hauptbatterie auf der rechten Seite erscheinen!</string>
+
+  <string name="theme_default">Standard</string>
+  <string name="theme_default_sideways">Gekippt</string>
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -49,7 +49,7 @@
   <string name="sett_textPos_Top">Oben</string>
   <string name="sett_textPos_Middle">Im Zentrum</string>
   <string name="sett_textPos_Bottom">Unten</string>
-  <string name="sett_textPos_Below">Unter den Icons</string></string>
+  <string name="sett_textPos_Below">Unter den Icons</string>
   <string name="sett_battSel_Both">Beide</string>
   <string name="sett_battSel_Main">Nur den internen Akku</string>
   <string name="sett_battSel_Dock">Nur den Dock-Akku</string>


### PR DESCRIPTION
- Unified mixture of "Akku" and "Batterie" to "Batterie" only. "Akku" would also be possible, but "Batterie" is the official wording and more common.
- Corrected imprecise translation of "margin"
- More precise translations allowing to understand the meaning more easily e.g. for text position
- Added missing translations (theme selection)
